### PR TITLE
Fix missing coordinate

### DIFF
--- a/src/ewkb.rs
+++ b/src/ewkb.rs
@@ -239,7 +239,11 @@ impl postgis::Point for Point {
     fn crds(&self) -> Vec<f64> {
         {
             if let Some(z) = self.opt_z() {
-                [self.x(), self.y(), z].to_vec()
+                if let Some(m) = self.opt_m() {
+                    [self.x(), self.y(), z, m].to_vec()
+                } else {
+                    [self.x(), self.y(), z].to_vec()
+                }
             } else {
                 [self.x(), self.y()].to_vec()
             }
@@ -284,7 +288,11 @@ impl postgis::Point for PointZ {
     fn crds(&self) -> Vec<f64> {
         {
             if let Some(z) = self.opt_z() {
-                [self.x(), self.y(), z].to_vec()
+                if let Some(m) = self.opt_m() {
+                    [self.x(), self.y(), z, m].to_vec()
+                } else {
+                    [self.x(), self.y(), z].to_vec()
+                }
             } else {
                 [self.x(), self.y()].to_vec()
             }
@@ -329,7 +337,11 @@ impl postgis::Point for PointM {
     fn crds(&self) -> Vec<f64> {
         {
             if let Some(z) = self.opt_z() {
-                [self.x(), self.y(), z].to_vec()
+                if let Some(m) = self.opt_m() {
+                    [self.x(), self.y(), z, m].to_vec()
+                } else {
+                    [self.x(), self.y(), z].to_vec()
+                }
             } else {
                 [self.x(), self.y()].to_vec()
             }
@@ -374,7 +386,11 @@ impl postgis::Point for PointZM {
     fn crds(&self) -> Vec<f64> {
         {
             if let Some(z) = self.opt_z() {
-                [self.x(), self.y(), z].to_vec()
+                if let Some(m) = self.opt_m() {
+                    [self.x(), self.y(), z, m].to_vec()
+                } else {
+                    [self.x(), self.y(), z].to_vec()
+                }
             } else {
                 [self.x(), self.y()].to_vec()
             }

--- a/src/twkb.rs
+++ b/src/twkb.rs
@@ -249,7 +249,11 @@ impl postgis::Point for Point {
     fn crds(&self) -> Vec<f64> {
         {
             if let Some(z) = self.opt_z() {
-                [self.x(), self.y(), z].to_vec()
+                if let Some(m) = self.opt_m() {
+                    [self.x(), self.y(), z, m].to_vec()
+                } else {
+                    [self.x(), self.y(), z].to_vec()
+                }
             } else {
                 [self.x(), self.y()].to_vec()
             }


### PR DESCRIPTION
Before this commit, when converting a geometry with four coordinates, the fourth one was lost.